### PR TITLE
fix privateKey to be contents of key file

### DIFF
--- a/src/clients/sftp.ts
+++ b/src/clients/sftp.ts
@@ -418,7 +418,7 @@ export async function openConnection(opts: SFTPConnectionOptions): Promise<SFTPC
         passphrase: privateKeyPassphrase,
         password: pwd,
         port: port,
-        privateKey: privateKeyFile,
+        privateKey: FS.readFileSync(privateKeyFile, {'encoding':'utf8'}),
         readyTimeout: readyTimeout,
         tryKeyboard: deploy_helpers.toBooleanSafe(opts.tryKeyboard),
         username: user,


### PR DESCRIPTION
the SFTP object for ssh2-sftp-client requires the privateKey key value to contain the actual contents of the key file, not the key filename. I am not sure if my change is the best way to code this (I've not written in typescript or much javascript before). But I took this from the ssh2-sftp-client example GitHub: https://github.com/jyu213/ssh2-sftp-client/blob/master/config/ftp_config_example.js

Before doing this, I always got an error about unable to parse key, and when I dumped out the key, it was just trying to use the file path instead of the actual key itself. After making this change, I am able to connect successfully.