### PR TITLE
Add support for FTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The extension supports the following destinations:
 | [Compiler](https://github.com/mkloubert/vscode-deploy-reloaded/wiki/target_compiler) |
 | [DropBox](https://github.com/mkloubert/vscode-deploy-reloaded/wiki/target_dropbox) |
 | [External Node.js based scripts](https://github.com/mkloubert/vscode-deploy-reloaded/wiki/target_script) |
-| [FTP](https://github.com/mkloubert/vscode-deploy-reloaded/wiki/target_ftp) |
+| [FTP(S)](https://github.com/mkloubert/vscode-deploy-reloaded/wiki/target_ftp) |
 | [Local or shared network folders inside a LAN](https://github.com/mkloubert/vscode-deploy-reloaded/wiki/target_local) |
 | [Mail (SMTP)](https://github.com/mkloubert/vscode-deploy-reloaded/wiki/target_mail) |
 | [SFTP](https://github.com/mkloubert/vscode-deploy-reloaded/wiki/target_sftp) |

--- a/src/clients/ftp.ts
+++ b/src/clients/ftp.ts
@@ -167,7 +167,11 @@ export interface FTPConnectionOptions {
     /**
      * A function that provides values for the connection.
      */
-    readonly valueProvider?: deploy_values.ValuesProvider;  
+    readonly valueProvider?: deploy_values.ValuesProvider;
+    /**
+     * Set to true for both control and data connection encryption, 'control' for control connection encryption only, or 'implicit' for implicitly encrypted control connection (this mode is deprecated in modern times, but usually uses port 990) Default: false, applies only when engine is set to 'ftp'
+     */
+    readonly secure?: boolean | "implicit";
 }
 
 /**
@@ -748,6 +752,7 @@ class FtpClient extends FTPClientBase {
                 conn.connect({
                     host: host, port: port,
                     user: user, password: pwd,
+                    secure: this.options.secure
                 });
             }
             catch (e) {

--- a/src/plugins/ftp.ts
+++ b/src/plugins/ftp.ts
@@ -141,6 +141,10 @@ export interface FTPTarget extends deploy_targets.Target {
      * The username.
      */
     readonly user?: string;
+    /**
+     * Set to true for both control and data connection encryption, 'control' for control connection encryption only, or 'implicit' for implicitly encrypted control connection (this mode is deprecated in modern times, but usually uses port 990) Default: false, applies only when engine is set to 'ftp'
+     */
+    readonly secure?: boolean | "implicit";
 }
 
 /**
@@ -467,6 +471,7 @@ class FTPPlugin extends deploy_plugins.AsyncFileClientPluginBase<FTPTarget,
                     supportsDeepDirectoryCreation: target.supportsDeepDirectoryCreation,
                     uploadCompleted: uploadCompleted,
                     user: user,
+                    secure: target.secure,
                     valueProvider: () => WORKSPACE.getValues(),
                 }),
                 getDir: (subDir) => {


### PR DESCRIPTION
Is this enough for enabling FTPS support? Basically added a configuration option to accept secure attribute, which tells, if `ftp` is used to use either explicit or implicit secure protocol. I just tried to put this together quickly, so any feedback appreciated.

#67 