### PR TITLE
File preview working

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -153,12 +153,25 @@ export async function openHtmlDocument(html: string, title?: string, id?: any): 
         NEW_DOC.title = deploy_helpers.toStringSafe(title).trim();
     }
 
-    if (HTML_DOCS) {
-        HTML_DOCS.push(NEW_DOC);
-    }
+    //Find eexisting column
+    const column = vscode.window.activeTextEditor
+        ? vscode.window.activeTextEditor.viewColumn
+        : undefined;
 
-    return await vscode.commands.executeCommand(OPEN_HTML_DOC_COMMAND,
-                                                NEW_DOC, HTML_DOCS);
+    //Create webview panel
+    const panel = vscode.window.createWebviewPanel(
+        "New files list",
+        NEW_DOC.title,
+        column || vscode.ViewColumn.One,
+        {
+            enableScripts: false,
+        }
+    );
+
+    //Load content into webview
+    panel.webview.html = NEW_DOC.body.toString();
+    return true;
+
 }
 
 /**


### PR DESCRIPTION
Listing changed files didn't seem to work since they updated VSCode.

I've updated the code to support the new WebView API so that previews can be shown correctly.

Steps:
1. Make sure "checkBeforeDeploy": true is present in your target configuration
2. Deploy workspace as normal
3. When asked if you wish to continue with the upload, select "no"
4. The updated file list will now be displayed