### PR TITLE
Fix compatibility with VS Code 1.59

### DIFF
--- a/src/sql/mysql.ts
+++ b/src/sql/mysql.ts
@@ -18,7 +18,7 @@
 import * as deploy_contracts from '../contracts';
 import * as deploy_helpers from '../helpers';
 import * as deploy_sql from '../sql';
-import * as MySQL from 'mysql';
+import * as MySQL from '../../node_modules/mysql';
 
 
 /**


### PR DESCRIPTION
Updated the out/sql/mysql.js MySQL dependency.

Make compatible with VS Code 1.59.